### PR TITLE
Close threads when finish

### DIFF
--- a/module2/python3_multithreading_example/example.py
+++ b/module2/python3_multithreading_example/example.py
@@ -1,22 +1,35 @@
 #!/usr/bin/python3
 
-import _thread
+# import _thread
+import threading
 import time
 
+
 # Define a function for the thread
-def print_time( threadName, delay):
-   count = 0
-   while count < 5:
-      time.sleep(delay)
-      count += 1
-      print ("%s: %s" % ( threadName, time.ctime(time.time()) ))
+def print_time(thread_name, delay):
+    count = 0
+    while count < 5:
+        time.sleep(delay)
+        count += 1
+        print("%s: %s" % (thread_name, time.ctime(time.time())))
+
 
 # Create two threads as follows
+NUM_THREADS = 2
+threads = []
 try:
-   _thread.start_new_thread( print_time, ("Thread-1", 2, ) )
-   _thread.start_new_thread( print_time, ("Thread-2", 4, ) )
+    for i in range(NUM_THREADS):
+        print("In main: creating thread {}".format(i))
+        x = threading.Thread(target=print_time, args=('Thread-{}'.format(i), 2 * (i + 1)))
+        threads.append(x)
+        x.start()
 except:
-   print ("Error: unable to start thread")
+    print("Error: unable to create thread")
 
-while 1:
-   pass
+try:
+    for thread in threads:
+        thread.join()
+except:
+    print("Error: unable to start thread")
+
+print("In main: All threads completed successfully")


### PR DESCRIPTION
I noticed that the original method somehow does not exit the program after all threads finish. Instead of using the lower-level _thread package, I updated the code to use the threading package. I also copied the info messages from the c++ version, so both programs generate similar results now. Since the Python version on Vocarum is 3.5, I used format instead of f-strings.