### PR TITLE
Fixed the issue when KERNEL_LOOP is greater than 1024

### DIFF
--- a/module6/register.cu
+++ b/module6/register.cu
@@ -35,7 +35,7 @@ __host__ void gpu_kernel(void)
 {
         const unsigned int num_elements = KERNEL_LOOP;
         const unsigned int num_threads = KERNEL_SIZE;
-        const unsigned int num_blocks = num_elements/num_threads;
+        const unsigned int num_blocks = (num_elements + num_threads - 1)/num_threads;
         const unsigned int num_bytes = num_elements * sizeof(unsigned int);
 
         unsigned int * data_gpu;

--- a/module6/register.cu
+++ b/module6/register.cu
@@ -1,7 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define KERNEL_LOOP 128
+#define KERNEL_LOOP 2048
+#define KERNEL_SIZE 128
 
 __host__ void wait_exit(void)
 {
@@ -33,7 +34,7 @@ __global__ void test_gpu_register(unsigned int * const data, const unsigned int 
 __host__ void gpu_kernel(void)
 {
         const unsigned int num_elements = KERNEL_LOOP;
-        const unsigned int num_threads = KERNEL_LOOP;
+        const unsigned int num_threads = KERNEL_SIZE;
         const unsigned int num_blocks = num_elements/num_threads;
         const unsigned int num_bytes = num_elements * sizeof(unsigned int);
 
@@ -61,7 +62,7 @@ __host__ void gpu_kernel(void)
 
         cudaFree((void* ) data_gpu);
         cudaDeviceReset();
-        wait_exit();
+//        wait_exit();
 }
 
 void execute_host_functions()


### PR DESCRIPTION
The original code assumes threads per block equals the total number of elements, in that case, the number of blocks always equal to 1. Since K80 only allows up to 1024 threads per block, the remaining calculations will be skipped. Hence, I created another global constant to fix the issue.

<img width="348" alt="WX20210227-172742@2x" src="https://user-images.githubusercontent.com/10616426/110228033-774a1b80-7ec3-11eb-8911-d259fb321577.png">
