### PR TITLE
module0 - sleep throws an error in newer Windows Kit versions. Conditionally in…

### DIFF
--- a/module0/hello_world_cl.c
+++ b/module0/hello_world_cl.c
@@ -12,6 +12,9 @@
 #else
 	#include <CL/cl.h>
 #endif
+#if _WIN32
+	#include <windows.h>
+#endif
 
 const char *KernelSource = "\n" \
 "__kernel void hello(              \n" \
@@ -111,6 +114,13 @@ int main(int argc, char** argv)
 	clReleaseKernel(kernel);
 	clReleaseCommandQueue(commands);
 	clReleaseContext(context);
-	sleep(1); // Leopard pty bug workaround.
+
+	// Leopard pty bug workaround.
+#if _WIN32
+	Sleep(1);
+#else
+	sleep(1);
+#endif
+
 	return 0;
 }


### PR DESCRIPTION
…clude windows.h for _WIN32 hosts and opt for Sleep from the Windows API.

See: https://learn.microsoft.com/en-us/cpp/c-runtime-library/obsolete-functions?view=msvc-170&redirectedfrom=MSDN