### PR TITLE
Fix implicit `sleep(1)` call in hello_world_cl.c

### DIFF
--- a/module0/hello_world_cl.c
+++ b/module0/hello_world_cl.c
@@ -14,6 +14,8 @@
 #endif
 #if _WIN32
 	#include <windows.h>
+#else
+	#include <unistd.h>
 #endif
 
 const char *KernelSource = "\n" \


### PR DESCRIPTION
Conditionally includes "unistd.h" for POSIX platforms to correctly reference the `sleep(1)` function currently in use by the file. This is required to compile on POSIX platforms with standard warnings/errors enabled.